### PR TITLE
fix: project management GH action

### DIFF
--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -6,9 +6,6 @@ name: 'Project Board Automation'
   pull_request:
     branches: [main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
-  pull_request_target:
-    branches: [main]
-    types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
     types: [submitted]
   pull_request_review_comment:
@@ -44,7 +41,7 @@ jobs:
       - name: 'Get linked issue id and state'
         id: linked-issue
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
         run: |
           gh api graphql -f query='
             query($pr_url: URI!) {


### PR DESCRIPTION
Close vegaprotocol/devops-infra#1555   

- use PAT rather than token so works cross public and private repos